### PR TITLE
add functions to reformat tracks to soccernet csv

### DIFF
--- a/assets/sn_categories.json
+++ b/assets/sn_categories.json
@@ -1,0 +1,58 @@
+{
+    "player": {
+        "supercategory": "object",
+        "id": 1
+    },
+    "goalkeeper": {
+        "supercategory": "object",
+        "id": 2
+    },
+    "referee": {
+        "supercategory": "object",
+        "id": 3
+    },
+    "ball": {
+        "supercategory": "object",
+        "id": 4
+    },
+    "pitch": {
+        "supercategory": "pitch",
+        "id": 5,
+        "lines": [
+            "Big rect. left bottom",
+            "Big rect. left main",
+            "Big rect. left top",
+            "Big rect. right bottom",
+            "Big rect. right main",
+            "Big rect. right top",
+            "Circle central",
+            "Circle left",
+            "Circle right",
+            "Goal left crossbar",
+            "Goal left post left",
+            "Goal left post right",
+            "Goal right crossbar",
+            "Goal right post left",
+            "Goal right post right",
+            "Middle line",
+            "Side line bottom",
+            "Side line left",
+            "Side line right",
+            "Side line top",
+            "Small rect. left bottom",
+            "Small rect. left main",
+            "Small rect. left top",
+            "Small rect. right bottom",
+            "Small rect. right main",
+            "Small rect. right top"
+        ]
+    },
+    "camera": {
+        "supercategory": "camera",
+        "id": 6
+    },
+    "other": {
+        "supercategory": "object",
+        "id": 7
+    }
+}

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import numpy as np
 from pitchlocalization import KeypointDetector, PitchFrame, ViewTransformer
 from team_assigner import TeamAssigner
 from tracker import Tracker, PlayerBallAssigner
-from utils import read_video, save_video, get_filename
+from utils import read_video, save_video, get_video_filename
 
 def main(
     input_video = "input_videos/08fd33_4.mp4",
@@ -16,7 +16,7 @@ def main(
     print('loading video')
     vod_frames = read_video(input_video)
 
-    filename = get_filename(input_video)
+    filename = get_video_filename(input_video)
 
     """
     TRACKING: initial detection and tracking

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,3 @@
-from .vod_utils import read_video, save_video
-from .bbox_utils import get_center_of_bbox, get_bottom_center_of_bbox, get_bbox_width, measure_distance, calculate_centroid
-from .input_utils import get_filename
+from .vod_utils import read_video, save_video, get_video_filename
+from .bbox_utils import get_center_of_bbox, get_bottom_center_of_bbox, get_bbox_width, get_bbox_height, measure_distance, calculate_centroid 
+from .data_utils import reformat_tracks

--- a/utils/bbox_utils.py
+++ b/utils/bbox_utils.py
@@ -15,6 +15,12 @@ def get_bbox_width(bbox):
 
     return x2 - x1
 
+def get_bbox_height(bbox):
+    
+    _, y1, _, y2 = bbox
+    
+    return y2 - y1
+
 def measure_distance(p1, p2):
 
     """

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -1,0 +1,101 @@
+import json
+import pandas as pd
+from utils import get_center_of_bbox, get_bbox_width, get_bbox_height
+
+def load_category_mapping():
+
+    with open('assets/sn_categories.json', 'r') as f:
+        category_mapping = json.load(f)
+
+    return category_mapping
+
+category_mapping = load_category_mapping()
+
+def process_track(track, track_id, id, image_id):
+    # get track features
+    cls_name = track.get("cls_name")
+    bbox = track.get("bbox")
+    jersey = track.get("jersey")
+    team = track.get("team")
+
+    # create attribute dict
+    attributes = {
+        "role": cls_name,
+        "jersey": jersey,
+        "team": team
+    }
+
+    # calculate relevant bbox values
+    centers = get_center_of_bbox(bbox)
+    x, y, _, _ = bbox
+    bbox_image = {
+        "x": bbox[0], "y": bbox[1],
+        "x_center": centers[0], "y_center": centers[1],
+        "w": get_bbox_width(bbox), "h": get_bbox_height(bbox)
+    }
+
+    track_row = {
+        "id": id,
+        "image_id": image_id,
+        "track_id": track_id,
+        "supercategory": category_mapping[cls_name]["supercategory"],
+        "category_id": category_mapping[cls_name]["id"],
+        "attributes": attributes,
+        "bbox_image": bbox_image,
+        "bbox_pitch": None,
+        "bbox_pitch_raw": None,
+        "lines": None,
+    }
+
+    return track_row
+
+def reformat_tracks(frames, tracks, save_csv, csv_path):
+
+    num_frames = len(frames)
+
+    player_tracks = tracks["players"]
+    referee_tracks = tracks["referees"]
+    ball_tracks = tracks["ball"]
+
+    id = 0
+    all_rows = []
+    for frame_num in range(num_frames):
+
+        rows = []
+        # get player track data
+        for player_id, track in player_tracks[frame_num].items():
+            player_track = process_track(track, player_id, id, frame_num)
+            rows.append(player_track)
+            id += 1
+
+        for referee_id, track in referee_tracks[frame_num].items():
+            track["cls_name"] = "referee"
+            referee_track = process_track(track, referee_id, id, frame_num)
+            rows.append(referee_track)
+            id += 1
+
+        # sort ids in ascending order
+        rows = sorted(rows, key = lambda row: row["track_id"])
+
+        for track in ball_tracks[frame_num].values():
+            track["cls_name"] = "ball"
+            ball_track = process_track(track, None, id, frame_num)
+            rows.append(ball_track)
+            id += 1
+
+        all_rows += rows
+
+    # create dataframe
+    tracks_df = pd.DataFrame(all_rows)
+
+    # assign track id for ball
+    ball_id = tracks_df.track_id.max() + 1
+
+    # fill ball's track_id
+    tracks_df.loc[tracks_df['category_id'] == 4, "track_id"] = ball_id
+
+    if csv_path is not None:
+
+        tracks_df.to_csv(csv_path)
+
+    return tracks_df

--- a/utils/input_utils.py
+++ b/utils/input_utils.py
@@ -1,8 +1,0 @@
-import os
-
-def get_filename(filepath):
-
-    _, filename = os.path.split(filepath)
-    filename, ext = os.path.splitext(filename)
-
-    return filename

--- a/utils/vod_utils.py
+++ b/utils/vod_utils.py
@@ -40,6 +40,14 @@ def save_video(frames: list, outpath: str):
     
     out.release()
 
+def get_video_filename(filepath):
+
+    _, filename = os.path.split(filepath)
+    filename, ext = os.path.splitext(filename)
+
+    return filename
+
+
 def generate_uuid() -> str:
 
     return uuid.uuid4().hex


### PR DESCRIPTION
1. added data_utils.py with functionality to convert YOLO tracks to a flattened csv format compatible with soccernet 
- YOLO format: object_category => frame_num => object_id => track
- soccernet columns: [id, image_id, track_id, supercategory, category_id, attributes, bbox_image, bbox_pitch, bbox_pitch_raw, lines]
2. added sn_categories.json mapping for soccernet categories and their respective supercategory and ids
3. added get_bbox_height to bbox_utils
4. refactored get_filename to get_video_filename and moved to vod_utils

